### PR TITLE
[MOBL-240] blueshift event logging made configurable

### DIFF
--- a/android-mparticle-kit/src/main/java/com/mparticle/kits/BlueshiftKit.java
+++ b/android-mparticle-kit/src/main/java/com/mparticle/kits/BlueshiftKit.java
@@ -322,16 +322,26 @@ public class BlueshiftKit extends KitIntegration implements
 
     // ** KitIntegration.PushListener **
 
+    private boolean isBlueshiftPush(Intent intent) {
+        Bundle bundle = intent != null ? intent.getExtras() : null;
+        Set<String> keys = bundle != null ? bundle.keySet() : null;
+        return keys != null && keys.contains(BSFT_MESSAGE_UUID);
+    }
+
     @Override
     public boolean willHandlePushMessage(Intent intent) {
         Configuration config = BlueshiftUtils.getConfiguration(getContext());
         if (config != null && !config.isPushEnabled()) {
+            BlueshiftLogger.w(TAG, "Blueshift push handling is disabled. Skipping...");
             return false;
         }
 
-        Bundle bundle = intent != null ? intent.getExtras() : null;
-        Set<String> keys = bundle != null ? bundle.keySet() : null;
-        return keys != null && keys.contains(BSFT_MESSAGE_UUID);
+        boolean isBlueshiftPush = isBlueshiftPush(intent);
+        if (!isBlueshiftPush) {
+            BlueshiftLogger.d(TAG, "Push message from outside Blueshift detected. Skipping...");
+        }
+
+        return isBlueshiftPush;
     }
 
     @Override

--- a/android-mparticle-kit/src/main/java/com/mparticle/kits/BlueshiftKit.java
+++ b/android-mparticle-kit/src/main/java/com/mparticle/kits/BlueshiftKit.java
@@ -35,25 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * This is an mParticle kit, used to extend the functionality of mParticle SDK. Most Kits are wrappers/adapters
- * to a 3rd party SDK, primarily used to map analogous public mParticle APIs onto a 3rd-party API/platform.
- * <p>
- * <p>
- * Follow the steps below to implement your kit:
- * <p>
- * - Edit ./build.gradle to add any necessary dependencies, such as your company's SDK
- * - Rename this file/class, using your company name as the prefix, ie "AcmeKit"
- * - View the javadocs to learn more about the KitIntegration class as well as the interfaces it defines.
- * - Choose the additional interfaces that you need and have this class implement them,
- * ie 'AcmeKit extends KitIntegration implements KitIntegration.PushListener'
- * <p>
- * In addition to this file, you also will need to edit:
- * - ./build.gradle (as explained above)
- * - ./README.md
- * - ./src/main/AndroidManifest.xml
- * - ./consumer-proguard.pro
- */
 public class BlueshiftKit extends KitIntegration implements
         KitIntegration.EventListener,
         KitIntegration.CommerceListener,


### PR DESCRIPTION
This change will enable the host app to configure what events should be sent to the Blueshift server directly.

By default, the `identify` event and all campaign stats events related to push & in-app will be sent to Blueshift directly. All other events will be sent to Blueshift via MParticle.