### PR TITLE
[MOBL-267] Remove the check for email before the identify call

### DIFF
--- a/android-mparticle-kit/build.gradle
+++ b/android-mparticle-kit/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'com.android.library'
 
-ext.kitVersion = '0.0.8'
+ext.kitVersion = '0.0.7'
 
 publish {
     repoName = 'maven'

--- a/android-mparticle-kit/build.gradle
+++ b/android-mparticle-kit/build.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'com.android.library'
 
+ext.kitVersion = '0.0.8'
+
 publish {
     repoName = 'maven'
     userOrg = 'blueshift-labs'
 
     groupId = 'com.blueshift'
     artifactId = 'android-mparticle-kit'
-    publishVersion = '0.0.7'
+    publishVersion = kitVersion
 
     desc = 'Blueshift mParticle Kit SDK'
     website = 'https://github.com/blueshift-labs/mparticle-android-integration-blueshift'
@@ -21,6 +23,8 @@ android {
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField 'String', 'KIT_VERSION', "\"$kitVersion\""
     }
     buildTypes {
         release {


### PR DESCRIPTION
## Changes:
- Remove the check on email presence before firing the _identify_ event.
- Send kit version as `bsft_mparticle_kit_version` in the _identify_ call.
- Log settings for debugging.